### PR TITLE
Set Ascendancy Portraits to `object-fit: cover` so they're not squished

### DIFF
--- a/src/components/ladder-portrait.tsx
+++ b/src/components/ladder-portrait.tsx
@@ -26,7 +26,7 @@ export function LadderPortrait({ entry, team }: Props) {
     >
       <AscendancyPortrait
         character_class={entry.character_class}
-        className="w-20 h-20 rounded-full"
+        className="w-20 h-20 rounded-full object-cover"
       />
       <div className="flex flex-col w-full">
         <span className="font-bold" style={{ color: team?.color || "inherit" }}>

--- a/src/components/pob.tsx
+++ b/src/components/pob.tsx
@@ -266,7 +266,7 @@ export function PoB({ pobString }: Probs) {
               <h1 className="flex items-center text-xl mb-1 gap-4">
                 <AscendancyPortrait
                   character_class={characterClass}
-                  className="w-14 h-14 rounded-full"
+                  className="w-14 h-14 rounded-full object-cover"
                 />
                 <span>
                   Level {pob.build.level}{" "}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -154,7 +154,7 @@ function Home() {
                               >
                                 <AscendancyPortrait
                                   character_class={character_class}
-                                  className="avatar w-15 h-15 sm:w-16 sm:h-16 xl:w-20 xl:h-20 rounded-full"
+                                  className="avatar w-15 h-15 sm:w-16 sm:h-16 xl:w-20 xl:h-20 rounded-full object-cover"
                                 ></AscendancyPortrait>
                               </div>
                             ))}

--- a/src/routes/scores/delve.tsx
+++ b/src/routes/scores/delve.tsx
@@ -117,7 +117,7 @@ export function DelveTab(): JSX.Element {
             <div className="flex items-center gap-2">
               <AscendancyPortrait
                 character_class={info.row.original.character_class}
-                className="w-8 h-8 rounded-full"
+                className="w-8 h-8 rounded-full object-cover"
               />
               <AscendancyName
                 character_class={info.row.original.character_class}

--- a/src/routes/scores/ladder.tsx
+++ b/src/routes/scores/ladder.tsx
@@ -123,7 +123,7 @@ export function LadderTab(): JSX.Element {
               <div className="flex items-center gap-2">
                 <AscendancyPortrait
                   character_class={info.row.original.character_class}
-                  className="w-10 h-10 rounded-full"
+                  className="w-10 h-10 rounded-full object-cover"
                 />
                 <div className="flex flex-col">
                   <span


### PR DESCRIPTION
# Description
The Ascendancy Portrait image assets used are not in a 1:1 aspect ratio so when one tries to fit them inside a square they get horizontally squished. Setting the image's `object-fit` CSS property to `cover` will size the image to maintain its original aspect ratio but still cover the entire container, clipping it if that makes it too big. ([MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit#cover))
This is achieved via the `object-cover` CSS class coming from [tailwind](https://tailwindcss.com/docs/object-fit).

# Examples
The bottom one is how it currently looks, top ones are with the new tailwind class added
<img width="241" height="128" alt="image" src="https://github.com/user-attachments/assets/7407b90b-67a7-4e46-a23e-d588e1767cc9" />
<img width="256" height="136" alt="image" src="https://github.com/user-attachments/assets/e0d8d2d9-ba52-40a7-b213-72e60ad96995" />
